### PR TITLE
Not trigger primary CI workflow when master pushed

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,9 +3,13 @@ format_version: '8'
 default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
 project_type: android
 trigger_map:
+  - push_branch: 'master'
+    workflow: empty
   - push_branch: '*'
     workflow: primary
 workflows:
+  empty:
+    description: Empty workflow for exclude branch from push trigger
   deploy:
     description: >
       ## How to get a signed APK


### PR DESCRIPTION
cause in case of rebase-flow it is redundant